### PR TITLE
⚡ Optimize ModelHubApp rendering by moving RAG demo to tab

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6331,7 +6331,7 @@
             "version": "8.15.0",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
             "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "bin": {
                 "acorn": "bin/acorn"

--- a/src/components/ModelHub/ModelHubApp.tsx
+++ b/src/components/ModelHub/ModelHubApp.tsx
@@ -14,7 +14,8 @@ import {
   Database,
   Flask,
   DownloadSimple,
-  Eye
+  Eye,
+  MagnifyingGlass
 } from "@phosphor-icons/react";
 import { APIKeyManager } from "./APIKeyManager";
 import { ModelExplorer } from "./ModelExplorer";
@@ -71,7 +72,7 @@ export function ModelHubApp() {
 
       <main className="container mx-auto px-6 py-8">
         <Tabs value={activeTab} onValueChange={setActiveTab} className="w-full">
-          <TabsList className="grid grid-cols-10 w-full mb-8 bg-card/50 backdrop-blur-sm border border-border">
+          <TabsList className="grid grid-cols-11 w-full mb-8 bg-card/50 backdrop-blur-sm border border-border">
             <TabsTrigger value="catalog" className="gap-2 data-[state=active]:bg-primary data-[state=active]:text-primary-foreground">
               <Database size={18} />
               <span className="hidden sm:inline">Catalog</span>
@@ -111,6 +112,10 @@ export function ModelHubApp() {
             <TabsTrigger value="saved" className="gap-2 data-[state=active]:bg-primary data-[state=active]:text-primary-foreground">
               <BookmarkSimple size={18} />
               <span className="hidden sm:inline">Saved</span>
+            </TabsTrigger>
+            <TabsTrigger value="rag" className="gap-2 data-[state=active]:bg-primary data-[state=active]:text-primary-foreground">
+              <MagnifyingGlass size={18} />
+              <span className="hidden sm:inline">RAG</span>
             </TabsTrigger>
           </TabsList>
 
@@ -171,12 +176,11 @@ export function ModelHubApp() {
           <TabsContent value="saved">
             <SavedPrompts />
           </TabsContent>
-        </Tabs>
 
-        {/* RAG Pipeline Section */}
-        <div className="mt-12">
-          <RAGPipelineDemo />
-        </div>
+          <TabsContent value="rag">
+            <RAGPipelineDemo />
+          </TabsContent>
+        </Tabs>
       </main>
 
       <footer className="border-t border-border mt-16 py-8 bg-card/30 backdrop-blur-sm">

--- a/tests/ModelHubApp.test.tsx
+++ b/tests/ModelHubApp.test.tsx
@@ -1,0 +1,65 @@
+import { render, screen, cleanup } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ModelHubApp } from '../src/components/ModelHub/ModelHubApp';
+import { vi, describe, it, expect, afterEach } from 'vitest';
+import React from 'react';
+
+// Mock child components
+vi.mock('@/components/ModelHub/APIKeyManager', () => ({ APIKeyManager: () => <div>APIKeyManager</div> }));
+vi.mock('@/components/ModelHub/ModelExplorer', () => ({ ModelExplorer: () => <div>ModelExplorer</div> }));
+vi.mock('@/components/ModelHub/EnhancedPromptTester', () => ({ EnhancedPromptTester: () => <div>EnhancedPromptTester</div> }));
+vi.mock('@/components/ModelHub/ResponseComparison', () => ({ ResponseComparison: () => <div>ResponseComparison</div> }));
+vi.mock('@/components/ModelHub/SavedPrompts', () => ({ SavedPrompts: () => <div>SavedPrompts</div> }));
+vi.mock('@/components/ModelHub/LiveModelTester', () => ({ LiveModelTester: () => <div>LiveModelTester</div> }));
+vi.mock('@/components/ModelHub/UnifiedModelCatalog', () => ({ UnifiedModelCatalog: () => <div>UnifiedModelCatalog</div> }));
+vi.mock('@/components/ModelHub/BatchModelTester', () => ({ BatchModelTester: () => <div>BatchModelTester</div> }));
+vi.mock('@/components/ModelHub/ConfigurationExporter', () => ({ ConfigurationExporter: () => <div>ConfigurationExporter</div> }));
+vi.mock('@/components/XAIExplainerDemo', () => ({ XAIExplainerDemo: () => <div>XAIExplainerDemo</div> }));
+
+// Mock the target component specifically to check for its presence
+vi.mock('@/components/ModelHub/RAGPipelineDemo', () => ({
+  RAGPipelineDemo: () => <div data-testid="rag-demo">RAG Pipeline Demo</div>
+}));
+
+// Mock ResizeObserver which is often used in UI libraries
+global.ResizeObserver = class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+
+// Mock matchMedia
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation(query => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(), // deprecated
+    removeListener: vi.fn(), // deprecated
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('ModelHubApp Performance', () => {
+  it('renders RAGPipelineDemo only when active', async () => {
+    const user = userEvent.setup();
+    render(<ModelHubApp />);
+
+    // Optimization check: RAGPipelineDemo should NOT be rendered initially
+    expect(screen.queryByTestId('rag-demo')).not.toBeInTheDocument();
+
+    // Click RAG tab
+    const ragTab = screen.getByRole('tab', { name: /RAG/i });
+    await user.click(ragTab);
+
+    // Verification: Now it should be present
+    expect(await screen.findByTestId('rag-demo')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Moves the `RAGPipelineDemo` component into a dedicated tab in `ModelHubApp` to prevent unconditional rendering. This improves performance by ensuring the heavy RAG demo component is only mounted when the user explicitly interacts with it. A regression test `tests/ModelHubApp.test.tsx` was added to verify that the component is absent from the DOM initially.

---
*PR created automatically by Jules for task [17258870001550586050](https://jules.google.com/task/17258870001550586050) started by @rubbers5018*