### PR TITLE
fix(ci): fix Claude Code Review workflow null outputs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -11,6 +11,7 @@ jobs:
       github.event.pull_request.draft == false &&
       github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
       pull-requests: write
@@ -25,7 +26,7 @@ jobs:
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@v1.0.5
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -33,3 +34,16 @@ jobs:
             Review this pull request for code quality, bugs, performance, and security issues.
             Use the repository's CLAUDE.md for style and convention guidance.
             Be constructive and specific. Post your review as a PR comment.
+
+      - name: Post fallback comment on failure
+        if: failure() || steps.claude-review.outputs.execution_file == ''
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const prNumber = context.payload.pull_request.number;
+            await github.rest.issues.createComment({
+              ...context.repo,
+              issue_number: prNumber,
+              body: '⚠️ Claude Code Review failed to produce output. The review step may have timed out or encountered an error. Please review the workflow logs for details.'
+            });


### PR DESCRIPTION
## Summary

Fixes #75 — Claude Code Review workflow producing null outputs for `execution_file`, `structured_output`, and `session_id`.

## Changes

- **Pinned `claude-code-action` to `v1.0.5`** instead of floating `@v1` — floating tags can resolve to broken versions
- **Added `timeout-minutes: 10`** to the job — prevents indefinite hanging when the action stalls
- **Added fallback comment step** — if the review step fails or produces empty `execution_file` output, a comment is posted to the PR explaining the failure instead of silently producing null outputs
- **Confirmed `anthropic_api_key` is used** (not `claude_code_oauth_token`) — this was already correct in the existing file

## Root Cause

The null outputs were most likely caused by the floating `@v1` tag resolving to a version with a bug, or the action timing out without a fallback. Pinning to a specific version and adding the fallback step ensures the workflow either posts a review or posts an explanatory comment — never silently null.

## Testing

- [x] Workflow YAML is valid
- [x] `anthropic_api_key` secret reference confirmed
- [x] Fallback step triggers on `failure()` or empty `execution_file`
- [ ] Live test: open a PR to trigger the workflow and verify a comment appears

## Closes

Closes #75