### PR TITLE
fix: update satisfy-required-checks.yml with project-relevant checks

### DIFF
--- a/.github/workflows/satisfy-required-checks.yml
+++ b/.github/workflows/satisfy-required-checks.yml
@@ -40,6 +40,9 @@ jobs:
             // Defaults mirror the CI workflow job/step names in build.yml.
             const defaultChecks = [
               "build",
+              "lint",
+              "typecheck",
+              "test",
             ];
 
             // REQUIRED_CHECKS should be provided as a newline-separated list.


### PR DESCRIPTION
## Changes

Updated `.github/workflows/satisfy-required-checks.yml` to replace Supabase-specific check names with project-relevant ones:

- Replaced `defaultChecks` array with: `build`, `lint`, `typecheck`, `test`
- Kept bot author allowlist unchanged (copilot-swe-agent, dependabot, github-actions)

## Implementation

Agent: **Blackbox CLI v2** (z-ai/glm-5.2)
Worktree: `/tmp/multi-agent-run-blackbox` on branch `fix/issue-74-satisfy-checks`

Closes #74